### PR TITLE
Apparently NG_DELAY_BOOTSTRAP! isn't required if there is no ng-app.

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -19,9 +19,6 @@ require.config({
 	]
 });
 
-// hey Angular, we're bootstrapping manually!
-window.name = "NG_DEFER_BOOTSTRAP!";
-
 require( [
 	'angular',
 	'app',


### PR DESCRIPTION
See https://github.com/angular/angular.js/pull/4009#issuecomment-24476755
