### PR TITLE
Remove argument services

### DIFF
--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -1,4 +1,4 @@
-define(['angular', 'services'], function(angular, services) {
+define(['angular', 'services'], function(angular) {
 	'use strict';
 
   /* Directives */


### PR DESCRIPTION
Reference to the services module is not needed here.
Module is instantiated via the dependency array and angular will get the service via DI.
