### PR TITLE
Remove baseUrl ( done via data-main )

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -5,7 +5,6 @@ require.config({
 		angularMocks: '../../bower_components/angular-mocks/angular-mocks',
 		text: '../../bower_components/requirejs-text/text'
 	},
-	baseUrl: 'app/js',
 	shim: {
 		'angular' : {'exports' : 'angular'},
 		'angularRoute': ['angular'],


### PR DESCRIPTION
http://requirejs.org/docs/api.html#config-baseUrl

If no baseUrl is explicitly set in the configuration, the default value will be the location of the HTML page that loads require.js. If a data-main attribute is used, that path will become the baseUrl.
