### PR TITLE
LOG_DEBUG is not supported anymore

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
 	autoWatch: true,
 
-	LogLevel: LOG_DEBUG,
+	LogLevel: config.LOG_DEBUG,
 
 	browsers: ['Firefox'],
 


### PR DESCRIPTION
`LOG_DEBUG is not supported anymore. Please use config.LOG_DEBUG instead.`

Fixed using `LOG_DEBUG`: instead `config.LOG_DEBUG`
